### PR TITLE
Submit v0.2.0 to cran

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 .gitignore
 .Rhistory
 .Rdata
+^CRAN-SUBMISSION$

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,0 +1,3 @@
+Version: 0.2.0
+Date: 2023-11-17 22:42:10 UTC
+SHA: 559a3e581289555ed9c531ebbff65ad7d66f090c

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: scutr
 Title: Balancing Multiclass Datasets for Classification Tasks
-Version: 0.1.2
+Version: 0.2.0
 Authors@R: 
     person(given = "Keenan",
            family = "Ganz",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# scutr 0.2.0
+
+ * Fixed an issue where inappropriate values of `k` were passed to `smotefamily::SMOTE` (#1)
+ * `undersample_*` functions now accept additional keyword arguments and pass these on to underlying functions, e.g. `stats::dist`.
+
 # scutr 0.1.0
 
 This is the initial version of the package. The following is available.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,16 +1,17 @@
-## Resubmission Comments
-* Changed parallel back-end; all parallel functions run on one core on Windows (this is documented and a warning is shown).
-
 ## Test environments
-* Local install of Windows 10 Education Edition v.20H2, R 4.1.0
-* win-builder.r-project.org, R 4.1.0 and devel
-* Microsoft Windows Server 2019 10.0.17763 (via GitHub actions), R 4.1.0
-* ubuntu 20.04 (via GitHub actions), R 4.1.0 and devel
-* macOS 10.15.7 (via GitHub actions), R 4.1.0 and devel
+* Local install of Windows 11 Pro v.22H2, R 4.3.2
+* win-builder.r-project.org, R 4.3.2 and devel
+* Microsoft Windows Server 2022 10.0.17763 (via GitHub actions), R 4.3.2
+* ubuntu 22.04 (via GitHub actions), R 4.3.2 and devel
+* macOS 12.7 (via GitHub actions), R 4.3.2 and devel
 
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
+0 errors | 0 warnings | 0 notes
 
-* This is a new release.
-* The flagged words in DESCRIPTION are not misspelled.
+## revdepcheck results
+
+We checked 1 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
+
+ * We saw 0 new problems
+ * We failed to check 0 packages


### PR DESCRIPTION
 * Fixed an issue where inappropriate values of `k` were passed to `smotefamily::SMOTE` (#1)
 * `undersample_*` functions now accept additional keyword arguments and pass these on to underlying functions, e.g. `stats::dist`.